### PR TITLE
Auth headers

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -83,7 +83,11 @@ module.exports = class Hub {
 
 		// Get the token
 		const access_token = await this.login()
-		extend(options, {qs: {access_token}})
+		extend(options, {
+			headers: {
+				Authorization: `Bearer ${access_token}`
+			}
+		})
 
 		// Prefix the path
 		options.path = path.join('/v2/service/', options.path)

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -135,7 +135,7 @@ describe('Digital Hub API', () => {
 			path: '/api'
 		})
 			.then(resp => {
-				expect(resp.headers).to.have.property('Authorization', hub.access_token)
+				expect(resp.headers).to.have.property('Authorization', 'Bearer inst_token')
 				done()
 			})
 			.catch(done)

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -55,8 +55,6 @@ describe('Digital Hub API', () => {
 			path: '/api'
 		})
 			.then(resp => {
-				expect(resp.qs).to.not.have.property('token')
-				expect(resp.qs).to.not.have.property('access_token')
 				expect(resp.headers).to.have.property('Authorization', 'Bearer token')
 				expect(resp).to.have.property('uri', `https://${tenant}/v2/service/api`)
 				done()
@@ -163,6 +161,8 @@ describe('Digital Hub API', () => {
 		})
 			.then(resp => {
 				expect(resp.qs).to.have.property('json', '{"key":"value"}')
+				expect(resp.qs).to.not.have.property('token')
+				expect(resp.qs).to.not.have.property('access_token')
 				done()
 			})
 			.catch(done)

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -129,13 +129,13 @@ describe('Digital Hub API', () => {
 			password
 		})
 
-		hub.access_token = 'inst_token'
+		hub.access_token = 'Bearer inst_token'
 
 		hub.api({
 			path: '/api'
 		})
 			.then(resp => {
-				expect(resp.headers).to.have.property('Authorization', 'Bearer ' + hub.access_token)
+				expect(resp.headers).to.have.property('Authorization', hub.access_token)
 				done()
 			})
 			.catch(done)

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -156,11 +156,13 @@ describe('Digital Hub API', () => {
 		hub.api({
 			path: '/api',
 			qs: {
-				json
+				json,
+				a: 1
 			}
 		})
 			.then(resp => {
 				expect(resp.qs).to.have.property('json', '{"key":"value"}')
+				expect(resp.qs).to.have.property('a', 1)
 				expect(resp.qs).to.not.have.property('token')
 				expect(resp.qs).to.not.have.property('access_token')
 				done()

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -129,7 +129,7 @@ describe('Digital Hub API', () => {
 			password
 		})
 
-		hub.access_token = 'Bearer inst_token'
+		hub.access_token = 'inst_token'
 
 		hub.api({
 			path: '/api'

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -55,7 +55,7 @@ describe('Digital Hub API', () => {
 			path: '/api'
 		})
 			.then(resp => {
-				expect(resp.qs.headers).to.have.property('Authorization', 'Bearer token')
+				expect(resp.headers).to.have.property('Authorization', 'Bearer token')
 				expect(resp).to.have.property('uri', `https://${tenant}/v2/service/api`)
 				done()
 			})
@@ -135,7 +135,7 @@ describe('Digital Hub API', () => {
 			path: '/api'
 		})
 			.then(resp => {
-				expect(resp.qs).to.have.property('access_token', hub.access_token)
+				expect(resp.headers).to.have.property('Authorization', hub.access_token)
 				done()
 			})
 			.catch(done)

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -135,7 +135,7 @@ describe('Digital Hub API', () => {
 			path: '/api'
 		})
 			.then(resp => {
-				expect(resp.headers).to.have.property('Authorization', hub.access_token)
+				expect(resp.headers).to.have.property('Authorization', 'Bearer ' + hub.access_token)
 				done()
 			})
 			.catch(done)

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -55,6 +55,8 @@ describe('Digital Hub API', () => {
 			path: '/api'
 		})
 			.then(resp => {
+				expect(resp.qs).to.not.have.property('token')
+				expect(resp.qs).to.not.have.property('access_token')
 				expect(resp.headers).to.have.property('Authorization', 'Bearer token')
 				expect(resp).to.have.property('uri', `https://${tenant}/v2/service/api`)
 				done()
@@ -166,5 +168,4 @@ describe('Digital Hub API', () => {
 			.catch(done)
 
 	})
-
 })

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -43,7 +43,7 @@ describe('Digital Hub API', () => {
 		expect(hub).to.be.instanceof(Hub)
 	})
 
-	it('should trigger a request and append an access_token', done => {
+	it('should trigger a request and append an auth token to the headers', done => {
 
 		const hub = new Hub({
 			tenant,
@@ -55,7 +55,7 @@ describe('Digital Hub API', () => {
 			path: '/api'
 		})
 			.then(resp => {
-				expect(resp.qs).to.have.property('access_token', 'token')
+				expect(resp.qs.headers).to.have.property('Authorization', 'Bearer token')
 				expect(resp).to.have.property('uri', `https://${tenant}/v2/service/api`)
 				done()
 			})


### PR DESCRIPTION
Changes:
- Moved access token into auth headers in line with the way the dashboard processes tokens.
- Changed tests accordingly.

fixes #6 