### PR TITLE
feat: Include shared assets in generated viewer links

### DIFF
--- a/samples/viewer/index.js
+++ b/samples/viewer/index.js
@@ -27,7 +27,7 @@ getViewerUrls(aud).catch(e => console.log(e))
 // Function to get the Viewer Links
 async function getViewerUrls(aud = '') {
 	const resp = await hub.api({
-		path: 'api/assets',
+		path: 'api/commonAsset',
 		qs: {
 			fields: [
 				'id',


### PR DESCRIPTION
Previously, the viewer script will only generate links to Hub's own assets.
With this change, shared assets will also be included.

All credits go to @MrSwitch

Fixes https://github.com/5app/dashboard/issues/5380