### PR TITLE
fix(bundling): bundling in webpack/typescript esm commonjs hack

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,8 @@
 const fetch = require('node-fetch')
 const extend = require('tricks/object/extend')
 
+// This is a hack for an instance whereby the node-fetch module is incorrectly being imported
+const fetchFunction = typeof fetch === 'function' ? fetch : fetch.default
 module.exports = class Hub {
 
 	constructor(opts) {
@@ -47,7 +49,7 @@ module.exports = class Hub {
 			}
 		}
 
-		const resp = await fetch(url, {...opts, headers})
+		const resp = await fetchFunction(url, {...opts, headers})
 
 		if (convertToJSON) {
 			return resp.json()


### PR DESCRIPTION
This seems to resolve an issue we had bundling Typescript with webpack....

When running the bundle we got the following bug, because the node-fetch was incorrectly bundled.

```json
{
	"errorType": "TypeError",
	"errorMessage": "fetch is not a function",
	"stack": [
		"TypeError: fetch is not a function","    at Hub.request (/var/task/app.js:2493:22)",
		"    at Hub.login (/var/task/app.js:2523:27)",
		"    at Hub.api (/var/task/app.js:2548:35)",
		"    at Runtime.saveReports [as handler] (/var/task/app.js:2302:28)",
		"    at Runtime.handleOnce (/var/runtime/Runtime.js:66:25)"
	]
}
```
