### PR TITLE
fix: Fix child hub setup readme, noissue

### DIFF
--- a/samples/settings/README.md
+++ b/samples/settings/README.md
@@ -6,5 +6,5 @@ Here are examples of configuring a Digital Hub
 # Setting a child hub
 
 ```bash
-node -r dotenv/config settings/set-child-hub [child_domain_id]
+node -r dotenv/config settings/set-child-hub child-hub.5app.com
 ```


### PR DESCRIPTION
The current documentation for setting a child hub implies that the ID of the child hub should be passed to the command, but it actually expects a URL. This is now corrected in the readme – I also went with showing an example URL directly in case the format (e.g. without `https://`) is relevant.